### PR TITLE
Add Job Metadata on Cronx

### DIFF
--- a/pkg/cronx/README.md
+++ b/pkg/cronx/README.md
@@ -254,3 +254,22 @@ cronx.New(cronx.Config{
     }(),
 })
 ```
+
+### My job requires certain information like current wave number, how can I get this information?
+This kind of information is stored inside metadata, which stored automatically inside `context`. 
+```go
+type subscription struct{}
+
+func (subscription) Run(ctx context.Context) error {
+	md, ok := cronx.GetJobMetadata(ctx)
+	if !ok {
+		return errors.New("cannot job metadata")
+	}
+
+	log.WithLevel(zerolog.InfoLevel).
+		Str("job", "subscription").
+		Interface("metadata", md).
+		Msg("is running")
+	return nil
+}
+```

--- a/pkg/cronx/context.go
+++ b/pkg/cronx/context.go
@@ -1,0 +1,34 @@
+package cronx
+
+import "context"
+
+type contextKey string
+
+// Context key for standardized context value.
+const (
+	CtxKeyJobMetadata = contextKey("cron-job-metadata")
+)
+
+// GetJobMetadata returns job metadata from current context, and status if it exists or not.
+func GetJobMetadata(ctx context.Context) (JobMetadata, bool) {
+	if ctx == nil {
+		return JobMetadata{}, false
+	}
+	val := ctx.Value(CtxKeyJobMetadata)
+
+	meta, ok := (val).(JobMetadata)
+	if !ok {
+		return JobMetadata{}, false
+	}
+
+	return meta, true
+}
+
+// SetJobMetadata stores current job metadata inside current context.
+func SetJobMetadata(ctx context.Context, meta JobMetadata) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	return context.WithValue(ctx, CtxKeyJobMetadata, meta)
+}

--- a/pkg/cronx/context_test.go
+++ b/pkg/cronx/context_test.go
@@ -1,0 +1,119 @@
+package cronx
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestGetJobMetadata(t *testing.T) {
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  JobMetadata
+		want1 bool
+	}{
+		{
+			name:  "Nil",
+			args:  args{},
+			want:  JobMetadata{},
+			want1: false,
+		},
+		{
+			name: "Broken type",
+			args: args{
+				ctx: context.WithValue(context.Background(), CtxKeyJobMetadata, "this is string"),
+			},
+			want:  JobMetadata{},
+			want1: false,
+		},
+		{
+			name: "Exists",
+			args: args{
+				ctx: context.WithValue(context.Background(), CtxKeyJobMetadata, JobMetadata{
+					EntryID:    1,
+					Wave:       2,
+					TotalWave:  3,
+					IsLastWave: true,
+				}),
+			},
+			want: JobMetadata{
+				EntryID:    1,
+				Wave:       2,
+				TotalWave:  3,
+				IsLastWave: true,
+			},
+			want1: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := GetJobMetadata(tt.args.ctx)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetJobMetadata() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetJobMetadata() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func TestSetJobMetadata(t *testing.T) {
+	type args struct {
+		ctx  context.Context
+		meta JobMetadata
+	}
+	tests := []struct {
+		name string
+		args args
+		want context.Context
+	}{
+		{
+			name: "Nil",
+			args: args{
+				ctx: nil,
+				meta: JobMetadata{
+					EntryID:    1,
+					Wave:       2,
+					TotalWave:  3,
+					IsLastWave: true,
+				},
+			},
+			want: context.WithValue(context.Background(), CtxKeyJobMetadata, JobMetadata{
+				EntryID:    1,
+				Wave:       2,
+				TotalWave:  3,
+				IsLastWave: true,
+			}),
+		},
+		{
+			name: "Exists",
+			args: args{
+				ctx: context.Background(),
+				meta: JobMetadata{
+					EntryID:    1,
+					Wave:       2,
+					TotalWave:  3,
+					IsLastWave: true,
+				},
+			},
+			want: context.WithValue(context.Background(), CtxKeyJobMetadata, JobMetadata{
+				EntryID:    1,
+				Wave:       2,
+				TotalWave:  3,
+				IsLastWave: true,
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SetJobMetadata(tt.args.ctx, tt.args.meta); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SetJobMetadata() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cronx/example/main.go
+++ b/pkg/cronx/example/main.go
@@ -52,9 +52,15 @@ func (everyJob) Run(context.Context) error {
 
 type subscription struct{}
 
-func (subscription) Run(context.Context) error {
+func (subscription) Run(ctx context.Context) error {
+	md, ok := cronx.GetJobMetadata(ctx)
+	if !ok {
+		return errors.New("cannot job metadata")
+	}
+
 	log.WithLevel(zerolog.InfoLevel).
 		Str("job", "subscription").
+		Interface("metadata", md).
 		Msg("is running")
 	return nil
 }
@@ -68,7 +74,7 @@ func main() {
 	// - location is time.Local
 	// - without any middleware
 	// cronx.Default()
-	// RegisterJobs()
+	// defer cronx.Stop()
 
 	// ===========================
 	// With Custom Configuration

--- a/pkg/cronx/example/main_test.go
+++ b/pkg/cronx/example/main_test.go
@@ -67,8 +67,15 @@ func Test_subscription_Run(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "Success",
-			args:    args{},
+			name: "Success",
+			args: args{
+				in0: cronx.SetJobMetadata(context.Background(), cronx.JobMetadata{
+					EntryID:    1,
+					Wave:       2,
+					TotalWave:  3,
+					IsLastWave: true,
+				}),
+			},
 			wantErr: false,
 		},
 	}

--- a/pkg/cronx/job_test.go
+++ b/pkg/cronx/job_test.go
@@ -119,7 +119,9 @@ func TestJob_UpdateStatus(t *testing.T) {
 
 func TestNewJob(t *testing.T) {
 	type args struct {
-		job JobItf
+		job        JobItf
+		waveNumber int64
+		totalWave  int64
 	}
 	tests := []struct {
 		name string
@@ -128,13 +130,17 @@ func TestNewJob(t *testing.T) {
 		{
 			name: "Success",
 			args: args{
-				job: Func(func(ctx context.Context) error { return nil }),
+				job:        Func(func(ctx context.Context) error { return nil }),
+				waveNumber: 1,
+				totalWave:  1,
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.NotNil(t, NewJob(tt.args.job))
+			got := NewJob(tt.args.job, tt.args.waveNumber, tt.args.totalWave)
+			t.Log(got)
+			assert.NotNil(t, got)
 		})
 	}
 }

--- a/pkg/cronx/page/status.go
+++ b/pkg/cronx/page/status.go
@@ -43,10 +43,10 @@ const statusTemplate = `
 		 }
 	</script>
 	<style type="text/css">
-        body > .ui.container {
-            margin-top: 3em;
-            padding-bottom: 3em;
-        }
+		 body > .ui.container {
+			 margin-top: 3em;
+			 padding-bottom: 3em;
+		 }
 	</style>
 	<title>Cronx</title>
 </head>
@@ -127,7 +127,13 @@ const statusTemplate = `
                         {{end}}
 				>
 					<td>{{.ID}}</td>
-					<td class="left aligned">{{.Job.Name}}</td>
+					<td class="left aligned">
+                        {{if gt .Job.TotalWave 1 }}
+                            {{.Job.Name}} ({{.Job.Wave}}/{{.Job.TotalWave}})
+                        {{else}}
+                            {{.Job.Name}}
+                        {{end}}
+					</td>
 					<td>
                         {{if eq .Job.Status "RUNNING"}}
 							<div class="ui yellow label">

--- a/pkg/cronx/page/status.gohtml
+++ b/pkg/cronx/page/status.gohtml
@@ -35,10 +35,10 @@
 		 }
 	</script>
 	<style type="text/css">
-        body > .ui.container {
-            margin-top: 3em;
-            padding-bottom: 3em;
-        }
+		 body > .ui.container {
+			 margin-top: 3em;
+			 padding-bottom: 3em;
+		 }
 	</style>
 	<title>Cronx</title>
 </head>
@@ -119,7 +119,13 @@
                         {{end}}
 				>
 					<td>{{.ID}}</td>
-					<td class="left aligned">{{.Job.Name}}</td>
+					<td class="left aligned">
+                        {{if gt .Job.TotalWave 1 }}
+                            {{.Job.Name}} ({{.Job.Wave}}/{{.Job.TotalWave}})
+                        {{else}}
+                            {{.Job.Name}}
+                        {{end}}
+					</td>
 					<td>
                         {{if eq .Job.Status "RUNNING"}}
 							<div class="ui yellow label">

--- a/pkg/cronx/server.go
+++ b/pkg/cronx/server.go
@@ -25,6 +25,7 @@ func NewServer(commandCtrl *CommandController) {
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
+	e.Use(middleware.CORS())
 	e.Use(middleware.Recover())
 	e.Use(middleware.RemoveTrailingSlash())
 


### PR DESCRIPTION
## Description
Improve cronx by adding:
- Total number of waves
- Current job wave number
- If the current job is the last wave

### Example
Get current job metadata on the run.
```
type subscription struct{}

func (subscription) Run(ctx context.Context) error {
	md, ok := cronx.GetJobMetadata(ctx)
	if !ok {
		return errors.New("cannot job metadata")
	}

	log.WithLevel(zerolog.InfoLevel).
		Str("job", "subscription").
		Interface("metadata", md).
		Msg("is running")
	return nil
}
```

### Other notable change
- Add `regex` package.
- Add release drafter bot.
- Add labeler bot.
- Add auto assigner bot.