### PR TITLE
 Allow Errorx Merge Fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/gomodule/redigo v1.8.4
 	github.com/gorilla/mux v1.8.0
+	github.com/imdario/mergo v0.3.12
 	github.com/jackc/pgx/v4 v4.13.0
 	github.com/json-iterator/go v1.1.10
 	github.com/labstack/echo/v4 v4.2.2

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMW
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
+github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=

--- a/pkg/errorx/v2/code.go
+++ b/pkg/errorx/v2/code.go
@@ -14,19 +14,19 @@ const (
 	CodeNotFound       Code = "not_found"       // Entity does not exist.
 	CodeGateway        Code = "gateway"         // Gateway or third party service return error.
 	CodeConfig         Code = "config"          // Wrong configuration.
-	CodeDB             Code = "db"              // Database operation error.
 	CodeCircuitBreaker Code = "circuit_breaker" // Circuit breaker error.
-	CodeMarshal        Code = "marshal"
-	CodeUnmarshal      Code = "unmarshal"
-	CodeConversion     Code = "conversion"
-	CodeEncryption     Code = "encryption"
-	CodeDecryption     Code = "decryption"
-	CodeDBScan         Code = "db_scan"
-	CodeDBExec         Code = "db_exec"
-	CodeDBQuery        Code = "db_query"
-	CodeDBBegin        Code = "db_begin"
-	CodeDBCommit       Code = "db_commit"
-	CodeDBRollback     Code = "db_rollback"
+	CodeMarshal        Code = "marshal"         // JSON marshal error.
+	CodeUnmarshal      Code = "unmarshal"       // JSON unmarshal error.
+	CodeConversion     Code = "conversion"      // Conversion error, e.g. string to time conversion.
+	CodeEncryption     Code = "encryption"      // Encryption error.
+	CodeDecryption     Code = "decryption"      // Decryption error.
+	CodeDB             Code = "db"              // Database operation error.
+	CodeDBScan         Code = "db_scan"         // Database scan error.
+	CodeDBExec         Code = "db_exec"         // Database exec error.
+	CodeDBQuery        Code = "db_query"        // Database query error.
+	CodeDBBegin        Code = "db_begin"        // Database begin transaction error.
+	CodeDBCommit       Code = "db_commit"       // Database commit error.
+	CodeDBRollback     Code = "db_rollback"     // Database rollback error.
 )
 
 // GetCode returns the code of the root error, if available. Otherwise returns CodeInternal.

--- a/pkg/errorx/v2/errorx.go
+++ b/pkg/errorx/v2/errorx.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+
+	"github.com/imdario/mergo"
 )
 
 var ServiceName = "peractio"
@@ -43,9 +45,19 @@ func E(args ...interface{}) error {
 			e.Code = arg
 
 		case Fields:
-			// Fields cannot be appended.
-			// New fields will always replace the old fields.
-			e.Fields = arg
+			// Previous fields is empty.
+			// Replace with arg directly.
+			if e.Fields == nil {
+				e.Fields = arg
+				continue
+			}
+
+			// Merge fields.
+			// If there is duplicate fields,
+			// The e.Fields has higher priority and won't be replaced with arg.
+			if err := mergo.Merge(&e.Fields, arg); err != nil {
+				e.Fields = arg
+			}
 
 		case Op:
 			e.OpTraces = append([]Op{arg}, e.OpTraces...)

--- a/pkg/errorx/v2/errorx_test.go
+++ b/pkg/errorx/v2/errorx_test.go
@@ -143,7 +143,7 @@ func TestE(t *testing.T) {
 		},
 	}
 
-	enableLog := true
+	enableLog := false
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := E(tt.args...)

--- a/pkg/errorx/v2/errorx_test.go
+++ b/pkg/errorx/v2/errorx_test.go
@@ -81,6 +81,27 @@ func TestE(t *testing.T) {
 			},
 		},
 		{
+			name: "3 layer with fields merged",
+			args: []interface{}{
+				E(
+					E(
+						New("timeout"),
+						Fields{
+							"user_id":   1,
+							"random_id": 2,
+							"actor_id":  3,
+						},
+						Op("userGateway.FindUser"),
+					),
+					Fields{
+						"actor_id": 777,
+					},
+					Message("handler-message"),
+					Op("userHandler.FindUser"),
+				),
+			},
+		},
+		{
 			name: "Invalid type",
 			args: []interface{}{
 				123,
@@ -122,7 +143,7 @@ func TestE(t *testing.T) {
 		},
 	}
 
-	enableLog := false
+	enableLog := true
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := E(tt.args...)


### PR DESCRIPTION
Since usually the error identifier on different application layers has different type identifiers.
It will be much easier if fields are merged together to construct a more detailed stack trace.